### PR TITLE
Bugfix/local mode cannot create more than one drug

### DIFF
--- a/thunorweb/webpack/thunorweb/js/plate_mapper.js
+++ b/thunorweb/webpack/thunorweb/js/plate_mapper.js
@@ -471,7 +471,7 @@ var plate_mapper = function () {
     var createCellLine = function(name, successCallback) {
         if(pyHTS.state.plateMapperLocalOnly === true) {
             var ids = util.getAttributeFromObjects(pyHTS.state.cell_lines, "id");
-            var newId = Math.max.apply(null, ids) + 1;
+            var newId = ids.length ? (Math.max.apply(null, ids) + 1) : 0;
             pyHTS.state.cell_lines.push({'id': newId, 'name': name});
             $('#cellline-typeahead').data('ttTypeahead').menu
                         .datasets[0].source =
@@ -506,7 +506,7 @@ var plate_mapper = function () {
     var createDrug = function(name, successCallback) {
         if(pyHTS.state.plateMapperLocalOnly === true) {
             var ids = util.getAttributeFromObjects(pyHTS.state.drugs, "id");
-            var newId = Math.max.apply(null, ids) + 1;
+            var newId = ids.length ? (Math.max.apply(null, ids) + 1) : 0;
             pyHTS.state.drugs.push({'id': newId, 'name': name});
             $('.hts-drug-typeahead.tt-input').data('ttTypeahead')
                         .menu.datasets[0].source =

--- a/thunorweb/webpack/thunorweb/js/plate_mapper.js
+++ b/thunorweb/webpack/thunorweb/js/plate_mapper.js
@@ -1849,7 +1849,7 @@ var plate_mapper = function () {
                     if (dr_id === -1) {
                         // cell line does not exist in DB
                         if(pyHTS.state.plateMapperLocalOnly === true) {
-                            dr_id = createCellLine(currDrug, function(){});
+                            dr_id = createDrug(currDrug, function(){});
                         } else {
                             drugsToCreate.push(currDrug);
                         }


### PR DESCRIPTION
When deploying Thunor locally via thunor-web-quickstart and using Plate Mapper in Local mode/Standalone, it is not possible to add more than one drug to wells.
How to reproduce:
1. Typical installation of Thunor on localhost via thunor-web-quickstart
2. Open Plate Mapper in local mode (without dataset)
3. Enter 2 different drugs either in the same well or different wells. In the example below I entered new drugs D1 and D2 into A1 of 96 well plate.
4. Press apply
5. Both drugs are now D1

It's caused by the ID of the drug which is in both cases = -Infinity (see images below)

Before pressing "Apply"
![image](https://github.com/alubbock/thunor-web/assets/135720136/0fbe8c28-fbd9-42fc-8b45-81d3846b48fc)

After pressing "Apply"
![image](https://github.com/alubbock/thunor-web/assets/135720136/f6e4c08d-6505-460f-b335-066112b62552)
