### PR TITLE
Missing return newId when creating new drug

### DIFF
--- a/thunorweb/webpack/thunorweb/js/plate_mapper.js
+++ b/thunorweb/webpack/thunorweb/js/plate_mapper.js
@@ -522,6 +522,7 @@ var plate_mapper = function () {
             pyHTS.state.drugs.push({'id': newId, 'name': name});
             updateDrugTypeAheads();
             successCallback();
+            return newId;
         } else {
             $.ajax({
                 type: 'POST',


### PR DESCRIPTION
When importing TSV file into Plate Mapper local, the first drug will be displayed as None in the table view.
![image](https://github.com/alubbock/thunor-web/assets/135720136/12912ae6-a0f9-40b4-9ca1-214b305c696d)
