### PR TITLE
build: bump thunor core, pin key requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
--r thunor/requirements.txt
+-e ./thunor[test]
+numpy==1.26.4
+pandas==2.2.2
+plotly==5.23.0
 Django==4.2.15
 django-allauth==64.0.0
 django-crispy-forms==1.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 numpy==1.26.4
 pandas==2.2.2
 plotly==5.23.0
+xlrd
 Django==4.2.15
 django-allauth==64.0.0
 django-crispy-forms==1.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ numpy==1.26.4
 pandas==2.2.2
 plotly==5.23.0
 xlrd
+python-magic
 Django==4.2.15
 django-allauth==64.0.0
 django-crispy-forms==1.14.0


### PR DESCRIPTION
Thunor core itself no longer pins requirements. Pin key requirements here for reproducible builds: numpy, pandas, and plotly.