### PR TITLE
fix: use hostname when warming fork

### DIFF
--- a/thunordjango/tests/test_wsgi.py
+++ b/thunordjango/tests/test_wsgi.py
@@ -1,0 +1,10 @@
+from django.test import RequestFactory
+from django.test import TestCase
+
+from thunordjango.wsgi import application
+
+
+class TestHandler(TestCase):
+    def test_handles_request(self):
+        rf = RequestFactory()
+        application.resolve_request(rf.get("/"))

--- a/thunordjango/wsgi.py
+++ b/thunordjango/wsgi.py
@@ -9,16 +9,19 @@ https://docs.djangoproject.com/en/1.10/howto/deployment/wsgi/
 
 import os
 from django.core.wsgi import get_wsgi_application
+from django.conf import settings
 try:
     from uwsgidecorators import postfork
     from django.test.client import Client
-except:
-    postfork = lambda func: func
+except ImportError:
+    def postfork(*args, **kwargs):
+        pass
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "thunordjango.settings")
 
 application = get_wsgi_application()
 
+
 @postfork
 def initialise():
-    Client().get('/')
+    Client(HTTP_HOST=settings.HOSTNAME).get('/')


### PR DESCRIPTION
thunor-web warms up new uwsgi forks using Client.get(). Make these requests use the correct HTTP Host header from settings. Also add unit test that uwsgi.py exports a valid application.