### PR TITLE
feat: use html5 for file downloads

### DIFF
--- a/thunorweb/serve_file.py
+++ b/thunorweb/serve_file.py
@@ -28,8 +28,6 @@ def serve_file(request, full_file_name, rename_to=None, content_type=None):
                                rename_to=rename_to,
                                content_type=content_type)
 
-    # Cookie needed for jquery-file-download plugin
-    response['Set-Cookie'] = 'fileDownload=true; path=/'
     return response
 
 

--- a/thunorweb/views/dataset_downloads.py
+++ b/thunorweb/views/dataset_downloads.py
@@ -37,7 +37,6 @@ def _plain_response(response_text):
     response = HttpResponse(response_text, content_type='text/plain')
     response['Content-Disposition'] = \
         'attachment; filename="download_failed.txt"'
-    response['Set-Cookie'] = 'fileDownload=true; path=/'
     return response
 
 

--- a/thunorweb/webpack/package.json
+++ b/thunorweb/webpack/package.json
@@ -21,7 +21,6 @@
     "file-saver": "^2.0.0",
     "font-awesome": "^4.7.0",
     "jquery": "^3.1.1",
-    "jquery-file-download": "^1.4.6",
     "jquery-ui": "^1.12.1",
     "jquery-ui-touch-punch": "^0.2.3",
     "plotly.js": "^2.34.0",

--- a/thunorweb/webpack/webpack.config.js
+++ b/thunorweb/webpack/webpack.config.js
@@ -57,8 +57,7 @@ var config = {
                  "datatables.net-select-bs",
                  "datatables.net-select-bs/css/select.bootstrap.css",
                  "datatables.net-buttons-bs",
-                 "datatables.net-buttons-bs/css/buttons.bootstrap.css",
-                 "jquery-file-download"]
+                 "datatables.net-buttons-bs/css/buttons.bootstrap.css"]
     },
 
     output: {


### PR DESCRIPTION
Remove jquery-file-download plugin. Download attachment files in new window as fallback if html5 blob method errors.