### PR TITLE
feat: S3 storage support

### DIFF
--- a/config-examples/nginx.site-basic.conf
+++ b/config-examples/nginx.site-basic.conf
@@ -36,7 +36,7 @@ server {
   # This should match DOWNLOADS_URL in settings.py
   location /_thunor_downloads {
     # For downloading dynamically generated files using X-Accel-Redirect
-    # This should match DOWNLOADS_ROOT in settings.py
+    # This should match DOWNLOADS_PREFIX in MEDIA_ROOT in settings.py
     alias /srv/thunor-files/downloads/;
      internal;
   }

--- a/config-examples/nginx.site-full.conf
+++ b/config-examples/nginx.site-full.conf
@@ -71,7 +71,7 @@ server {
   # This should match DOWNLOADS_URL in settings.py
   location /_thunor_downloads {
     # For downloading dynamically generated files using X-Accel-Redirect
-    # This should match DOWNLOADS_ROOT in settings.py
+    # This should match DOWNLOADS_PREFIX in MEDIA_ROOT in settings.py
     alias /srv/thunor-files/downloads/;
      internal;
   }

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ django-webpack-loader==3.1.1
 psycopg2==2.9.9
 sentry-sdk[django]==2.13.0
 uwsgi==2.0.26
+django-storages[s3]==1.14.4

--- a/thunorweb/plate_parsers.py
+++ b/thunorweb/plate_parsers.py
@@ -725,5 +725,6 @@ class PlateFileParser(object):
                                       })
             except PlateFileParseException as e:
                 self._results.append({'success': False, 'error': e})
+                self.plate_file.delete()
 
         return self._results


### PR DESCRIPTION
Add s3 support for file storage, via django-storages package.
Delete uploaded platefiles if they cannot be parsed.