### PR TITLE
ci: mitigate race condition in CI

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -83,6 +83,7 @@ jobs:
             echo "GitHub Tag: $GITHUB_TAG"
           fi
           cd thunor-web-quickstart
+          git pull
           cp ../thunorctl.py .
           cp ../docker-compose.services.yml .
           cp ../docker-compose.certbot.yml .


### PR DESCRIPTION
CI sometimes fails due to quickstart repo having been changed by another commit during the build process, leading to an out of date repo race condition. Reduce the critical window by running a git pull before making changes.