### PR TITLE
chore: upgrade to thunor v1.0

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -25,8 +25,6 @@ jobs:
           docker --version
           docker compose version
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          submodules: true
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
@@ -62,8 +60,6 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
       - name: Checkout Thunor Web
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          submodules: true
       - name: Checkout Quickstart Repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "thunor"]
-	path = thunorcore
-	url = https://github.com/alubbock/thunor.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN mkdir $THUNOR_HOME
 WORKDIR $THUNOR_HOME
 
 ADD requirements.txt $THUNOR_HOME
-ADD thunorcore $THUNOR_HOME/thunorcore
 RUN pip3 install --no-cache-dir -r requirements.txt
 RUN dpkg --purge gcc g++ libhdf5-dev libpcre2-dev
 CMD ["uwsgi", "--master", "--socket", ":8000", "--module", "thunordjango.wsgi", "--uid", "www-data", "--gid", "www-data", "--enable-threads"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e ./thunorcore[test]
+thunor>=1.0,<2
 numpy==2.4.4
 pandas==3.0.2
 plotly==6.6.0

--- a/thunorweb/pandas.py
+++ b/thunorweb/pandas.py
@@ -503,10 +503,10 @@ def df_curve_fits(dataset_ids, stat_type,
     }, inplace=True)
     base_params.set_index(['dataset_id', 'cell_line', 'drug'], inplace=True)
 
-    base_params._drmetric = stat_type
+    base_params.attrs['drmetric'] = stat_type
     if stat_type == 'viability':
-        base_params._viability_time = viability_time
-        base_params._viability_assay = 'default'
+        base_params.attrs['viability_time'] = viability_time
+        base_params.attrs['viability_assay'] = 'default'
 
     return base_params
 

--- a/thunorweb/tests/__init__.py
+++ b/thunorweb/tests/__init__.py
@@ -1,14 +1,5 @@
 import importlib.resources
-import os
 
 
 def get_thunor_test_file(filename):
-    try:
-        return importlib.resources.files('thunor').joinpath(filename)
-    except OSError:
-        # Provide a method to load from filesystem within Docker container
-        fn = os.path.join('thunorcore/thunor', filename)
-        if os.path.exists(fn) and os.path.isfile(fn):
-            return fn
-
-        raise
+    return importlib.resources.files('thunor').joinpath(filename)

--- a/thunorweb/views/plots.py
+++ b/thunorweb/views/plots.py
@@ -571,7 +571,7 @@ def _dose_response_plot(request, dataset, dataset2_id,
                         datasets,
                         drug_id,
                         cell_line_id,
-                        viability_time=base_params[0]._viability_time.total_seconds() / SECONDS_TO_HOURS
+                        viability_time=base_params[0].attrs['viability_time'].total_seconds() / SECONDS_TO_HOURS
                     )
             except NoDataException:
                 return HttpResponse(
@@ -585,8 +585,8 @@ def _dose_response_plot(request, dataset, dataset2_id,
     with warnings.catch_warnings(record=True) as w:
         fit_params = [fit_params_from_base(
             base_param_set,
-            ctrl_resp_data=ctrl_resp_data,
-            expt_resp_data=expt_resp_data,
+            ctrl_data=ctrl_resp_data,
+            expt_data=expt_resp_data,
             include_response_values=include_response_values,
             custom_ic_concentrations=ic_concentrations,
             custom_ec_concentrations=ec_concentrations,
@@ -615,8 +615,8 @@ def _dose_response_plot(request, dataset, dataset2_id,
         fit_params.columns = ['label',
                               'dip__{}'.format(dr_par),
                               'viability__{}'.format(dr_par)]
-        fit_params._viability_time = base_params[1]._viability_time
-        fit_params._drmetric = 'compare'
+        fit_params.attrs['viability_time'] = base_params[1].attrs['viability_time']
+        fit_params.attrs['drmetric'] = 'compare'
         dr_par, dr_par_two = fit_params.columns[1:]
     else:
         fit_params = fit_params[0]


### PR DESCRIPTION
## Summary

Upgrades the thunor core dependency to v1.0 and migrates from the git submodule to a standard PyPI dependency.

**thunor-web changes:**
- Fix API compatibility with thunor v1.0: replace deprecated private DataFrame attributes (`_drmetric`, `_viability_time`, `_viability_assay`) with the public `.attrs` dict
- Rename `fit_params_from_base` kwargs `ctrl_resp_data`/`expt_resp_data` → `ctrl_data`/`expt_data`
- Replace `thunorcore` git submodule with `thunor>=1.0,<2` from PyPI — no more `--recursive` clone or submodule init
- Remove `ADD thunorcore` from Dockerfile and `submodules: true` from CI checkout steps
- Simplify `get_thunor_test_file` (drops Docker filesystem fallback, no longer needed)

**thunor v1.0 highlights (user-facing):**
- Vectorised DIP rate calculation — significantly faster for large datasets
- Combination wells with incomplete data now warn instead of raising an exception
- Fix for plot labels when using single-level groupby
- HDF5 files now store a schema version for forward/backward compatibility warnings
- Fix for `popt_rel` property returning incorrect values in curve fitting