### PR TITLE
fix(ci): checkout thunor-web before copying files to quickstart

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -106,6 +106,8 @@ jobs:
           docker buildx imagetools create $TAGS \
             alubbock/thunorweb:dev-amd64 \
             alubbock/thunorweb:dev-arm64
+      - name: Checkout Thunor Web
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Checkout Quickstart Repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:


### PR DESCRIPTION
## Summary

- The `merge-manifests` job was missing a checkout of the thunor-web repo before copying files (`thunorctl.py`, `docker-compose.services.yml`, etc.) into the quickstart repo
- This caused the CI failure: `cp: cannot stat '../thunorctl.py': No such file or directory`
- Added a `Checkout Thunor Web` step before the `Checkout Quickstart Repo` step, matching the pattern used in the `build-image` job

Fixes https://github.com/alubbock/thunor-web/actions/runs/24416555036/job/71328174055