### PR TITLE
chore: remove obsolete Compose v1 artefacts

### DIFF
--- a/docker-compose.certbot.yml
+++ b/docker-compose.certbot.yml
@@ -1,4 +1,3 @@
-version: '2.1'
 services:
   certbot:
     image: certbot/certbot

--- a/docker-compose.services.yml
+++ b/docker-compose.services.yml
@@ -1,4 +1,3 @@
-version: '2.1'
 services:
   app:
     image: alubbock/thunorweb:latest

--- a/thunorctl.py
+++ b/thunorctl.py
@@ -51,7 +51,6 @@ class ThunorCmdHelper(object):
         if self.args.dry_run:
             return 0
         env = os.environ.copy()
-        env['COMPOSE_INTERACTIVE_NO_CLI'] = '1'
         p = subprocess.Popen(
             cmd, cwd=self.cwd, env=env,
             stdout=subprocess.PIPE if capture_output else None,


### PR DESCRIPTION
## Summary

- Remove `version: '2.1'` from `docker-compose.services.yml` and `docker-compose.certbot.yml` — this key is deprecated in the Compose Specification and produces a warning in current `docker compose`
- Remove `COMPOSE_INTERACTIVE_NO_CLI=1` from `_run_cmd()` in `thunorctl.py` — this env var was a workaround for the standalone `docker-compose` v1 CLI and is a no-op in Compose v2

Note: may have a trivial conflict with #267 (both touch `thunorctl.py` in different sections).