### PR TITLE
chore(docker): pin uv version, add build cache and healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ LABEL org.opencontainers.image.authors="code@alexlubbock.com"
 ENV PYTHONUNBUFFERED=1
 ENV THUNOR_HOME=/thunor
 
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.6@sha256:b1e699368d24c57cda93c338a57a8c5a119009ba809305cc8e86986d4a006754 /uv /bin/uv
 
 RUN apt update && apt install -y libpq-dev gcc g++ libmagic1 libpcre2-dev media-types libhdf5-dev \
   && rm -rf /var/lib/apt/lists/*
@@ -12,11 +12,13 @@ RUN mkdir $THUNOR_HOME
 WORKDIR $THUNOR_HOME
 
 ADD pyproject.toml uv.lock $THUNOR_HOME/
-RUN uv sync --frozen --no-dev
+RUN --mount=type=cache,target=/root/.cache/uv uv sync --frozen --no-dev
 RUN dpkg --purge gcc g++ libhdf5-dev libpcre2-dev
 
 ENV PATH="/thunor/.venv/bin:$PATH"
 
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+    CMD python -c "import socket; s=socket.socket(); s.settimeout(5); s.connect(('127.0.0.1', 8000)); s.close()"
 CMD ["uwsgi", "--master", "--socket", ":8000", "--module", "thunordjango.wsgi", "--uid", "www-data", "--gid", "www-data", "--enable-threads"]
 ADD manage.py $THUNOR_HOME
 ADD thunordjango $THUNOR_HOME/thunordjango

--- a/config-examples/docker-compose.complete.yml
+++ b/config-examples/docker-compose.complete.yml
@@ -25,7 +25,8 @@ services:
       - static-assets:/srv/thunor-static/:ro
       - $THUNORHOME/_state/certbot/:/etc/letsencrypt/:ro
     depends_on:
-      - app
+      app:
+        condition: service_healthy
   postgres:
     extends:
       file: docker-compose.services.yml


### PR DESCRIPTION
## Summary

- **Pin uv to immutable digest** (`0.11.6@sha256:b1e699...`) instead of `:latest` — prevents silent version drift between builds
- **BuildKit cache mount** for `uv sync` — skips package re-download when `pyproject.toml`/`uv.lock` are unchanged, speeding up local rebuilds
- **`HEALTHCHECK`** on the app container (TCP connect to uwsgi port 8000) — enables `condition: service_healthy` in dependent services
- **nginx `depends_on`** updated to `condition: service_healthy` for the app — nginx now waits for uwsgi to be accepting connections before starting