### PR TITLE
chore(ci): remove single-value matrix and add coverage config

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -14,11 +14,6 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        dev: ['--dev']  # Running non-dev takes hours
-    env:
-      DEVFLAG: ${{ matrix.dev }}
     steps:
       - name: Print Docker Compose version
         run: |
@@ -29,17 +24,13 @@ jobs:
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
           python-version: '3.14'
-      - name: Run thunorbld.py init/testinit
-        run: |
-          if [[ $DEVFLAG == "--dev" ]]; then python thunorbld.py init; fi
-          if [[ $DEVFLAG == "" ]]; then python thunorbld.py testinit; fi
+      - name: Run thunorbld.py init
+        run: python thunorbld.py init
       - name: Test suite
-        run: python thunorbld.py $DEVFLAG test
+        run: python thunorbld.py --dev test
       - name: Generate coverage XML
-        if: ${{ matrix.dev == '--dev' }}
         run: uv run coverage xml
       - name: Upload coverage
-        if: ${{ matrix.dev == '--dev' }}
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,3 +32,7 @@ dev = [
 
 [tool.uv]
 package = false
+
+[tool.coverage.run]
+source = ["thunorweb", "thunordjango"]
+omit = ["*/migrations/*", "thunorweb/_version.py"]


### PR DESCRIPTION
## Summary

- **Remove CI matrix** from the `build` job — it contained a single value (`--dev`) with a comment explaining why the other value was removed. Replaced with a hardcoded `--dev` flag, dropping all `matrix.dev` conditionals.
- **`[tool.coverage.run]`** added to `pyproject.toml` — constrains coverage measurement to `thunorweb` and `thunordjango`, excluding migrations and the generated `_version.py`, so the coverage percentage reflects actual application code.